### PR TITLE
Fix enemy decomposition.

### DIFF
--- a/scripts/enemy.gd
+++ b/scripts/enemy.gd
@@ -22,6 +22,7 @@ func _physics_process(delta):
 	if animator.animation == "dead":
 		await get_tree().create_timer(decomposition_time).timeout
 		queue_free()
+		return
 	
 	if knock:
 		if health <= 0:


### PR DESCRIPTION
Testing godot with your project aaaand....

Issue: Enemy decomposition was still running last frame before scheduled delete.
Fix: Return from `_physics_process` on deletion.